### PR TITLE
Draft: More visible tabs

### DIFF
--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -290,6 +290,7 @@ section.window-content{
   border: gray;
   border-width: 1px 1px 0px 1px;
   border-style: solid;
+  background: rgba(173, 151, 101, 0.3);
 }
 
 .deltagreen .tabs .item.active {

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -287,13 +287,16 @@ section.window-content{
   padding: 5px 10px 0px 10px;
   border-radius: 5px 5px 0px 0px;
   border-color: #000;
+  border: gray;
+  border-width: 1px 1px 0px 1px;
+  border-style: solid;
 }
 
 .deltagreen .tabs .item.active {
   text-shadow: none;
   font-style: italic;
   border: #000;
-  border-width: 1px 1px 0px 1px;
+  border-width: 2px 2px 0px 2px;
   border-style: solid;
 }
 


### PR DESCRIPTION
When playing for the first time recently, there were multiple instances where the player's could not find the tabs (Skills, Physical, Mental, Gear, C.V., Contacts) on their character sheet. To be clear, this was not a bug, but more of a visibility issue. On certain tabs, they become really difficult to see/find. 

For example, in the following, there is little that distinguishes the tabs from the header for the contacts page: 
![image](https://user-images.githubusercontent.com/72114365/194153940-45929f1e-aff8-43d4-93ed-1667d94ca08c.png)

This PR hopefully makes the tabs more easily viewable. Leaving it as a Draft for now since maybe you have a better idea on how to solve this problem. This is how my edit looks:

![unknown](https://user-images.githubusercontent.com/72114365/194156465-e0fe1295-b64a-453b-92cc-6b4c67db11c1.png)
