### PR TITLE
Add option to delete original item when dragged to another sheet

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -205,7 +205,7 @@ export class DeltaGreenActorSheet extends ActorSheet {
 
     // Rollable abilities - bind to everything with the 'Rollable' class
     //html.find('.rollable').click(this._onRoll.bind(this));
-    html.find('.rollable').mousedown(this._onRoll.bind(this));
+    html.find('.rollable').click(this._onRoll.bind(this));
 
     // Macro for toggling an item's equipped state
     html.find('.equipped-item').mousedown(this._onEquippedStatusChange.bind(this));
@@ -825,8 +825,18 @@ export class DeltaGreenActorSheet extends ActorSheet {
   }
 
   /** @override */
-  _onDrop(event){
+  async _onDrop(event){
     super._onDrop(event);
+    // If alt key is held down, we will delete the original document.
+    if (event.altKey) {
+      // This is from Foundry. It will get the item data from the event.
+      const dragData = TextEditor.getDragEventData(event);
+      // Make sure that we are dragging an item, otherwise this doesn't make sense.
+      if (dragData.type = "Item") {
+        const item = fromUuidSync(dragData.uuid);
+        await item.delete()
+      }
+    }
   }
 
   activateEditor(target, editorOptions, initialContent) {

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -205,7 +205,7 @@ export class DeltaGreenActorSheet extends ActorSheet {
 
     // Rollable abilities - bind to everything with the 'Rollable' class
     //html.find('.rollable').click(this._onRoll.bind(this));
-    html.find('.rollable').click(this._onRoll.bind(this));
+    html.find('.rollable').mouseup(this._onRoll.bind(this));
 
     // Macro for toggling an item's equipped state
     html.find('.equipped-item').mousedown(this._onEquippedStatusChange.bind(this));


### PR DESCRIPTION
This PR introduces a feature that allows you to delete the original item when dragging items between sheets (by holding the `Alt` key when dropping). This mimics giving a player an item and saves time by not having to manually delete afterwards.

Steps to test: 

1. Create two actors and give them each some items.
2. Open both actor sheets and drag items between the two.
3. Note, items are duplicated onto the receiving actor but still exists on the original actor too.
4. Drag items between the two sheets, this time holding down the `Alt` key.
5. Note, item is created on the receiving actor and deleted from the host actor. 

