### PR TITLE
Fix Inhuman roll check for stat

### DIFF
--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -438,22 +438,22 @@ export async function showModifyDamageRollDialogue(actor, label, originalFormula
 
 export function skillIsStatTest(skillName){
   try{
-    if(skillName.toUpperCase() === game.i18n.localize("DG.Attributes.str").toUpperCase()){
+    if(skillName === game.i18n.localize("DG.Attributes.str").toUpperCase() + "x5"){
       return true;
     }
-    if(skillName.toUpperCase() === game.i18n.localize("DG.Attributes.con").toUpperCase()){
+    if(skillName === game.i18n.localize("DG.Attributes.con").toUpperCase() + "x5"){
       return true;
     }
-    if(skillName.toUpperCase() === game.i18n.localize("DG.Attributes.dex").toUpperCase()){
+    if(skillName === game.i18n.localize("DG.Attributes.dex").toUpperCase() + "x5"){
       return true;
     }
-    if(skillName.toUpperCase() === game.i18n.localize("DG.Attributes.int").toUpperCase()){
+    if(skillName === game.i18n.localize("DG.Attributes.int").toUpperCase() + "x5"){
       return true;
     }
-    if(skillName.toUpperCase() === game.i18n.localize("DG.Attributes.pow").toUpperCase()){
+    if(skillName === game.i18n.localize("DG.Attributes.pow").toUpperCase() + "x5"){
       return true;
     }
-    if(skillName.toUpperCase() === game.i18n.localize("DG.Attributes.cha").toUpperCase()){
+    if(skillName === game.i18n.localize("DG.Attributes.cha").toUpperCase() + "x5"){
       return true;
     }
     else{


### PR DESCRIPTION
Hi, just noticed something. When checking whether the stat roll is Inhuman, module checks if the rolled skill is a stat. However, the name passed looks like STATx5 (i.e. STRx5, CONx5), while `skillIsStatTest` function checks just for the stat name (i.e. STR, CON). Because of this, Inhuman rolls aren't properly detected. This PR fixes this.

There is no need for `.toUpperCase()` for the `skillName` in this function, since the `actor-sheet.js:_onRoll()` function already converts the stat name to upper case.

With this change, the rolls correctly detect crits for Inhuman rolls.