### PR TITLE
Fix private san rolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Version 1.3.2 - 2023-XX-XX
 
+- Enhancement - When hitting a breakpoint, current SAN now turns bold and red, to help indicate you need to reset your breaking point.
+- Fix [Github #86] - You can now right-click again to get the modify roll dialog, instead of just shift-click.
 - Fix [Github #87] - SAN rolls are hidden properly again if GM chooses.
+- Fix [Github #97] - Fixed broken tooltip on SAN that did not show current break point anymore.
 
 ### Version 1.3.1 - 2023-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release/Patch Notes
 
+### Version 1.3.2 - 2023-XX-XX
+
+- Fix [Github #87] - SAN rolls are hidden properly again if GM chooses.
+
 ### Version 1.3.1 - 2023-09-23
 
 - Enhancement - Changed pause icon to be Delta Green logo.

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -129,6 +129,11 @@ form.program-style {
   color: #999999;
 }
 
+input.breaking-point-hit{
+  color: rgb(117, 0, 0);
+  font-weight: bold;
+}
+
 .dg-red {
   color: rgb(117, 0, 0);
 }

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -48,6 +48,7 @@
 }
 
 /* Override the default Foundry CSS to add the padding we removed from the outer window back in */
+.deltagreen section.window-content form.locked,
 .deltagreen section.window-content form.editable {
   padding: 6px 6px 6px 6px !important;
 }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -237,7 +237,8 @@ export default class DeltaGreenActorSheet extends ActorSheet {
 
     // Rollable abilities - bind to everything with the 'Rollable' class
     html.find(".rollable").click(this._onRoll.bind(this));
-
+    html.find('.rollable').contextmenu(this._onRoll.bind(this)); // this is for right-click, which triggers the roll modifier dialogue for most rolls
+    
     html.find(".toggle-untrained").click(() =>
       this.actor.update({
         "system.showUntrainedSkills": !this.actor.system.showUntrainedSkills,

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -223,6 +223,13 @@ export default class DeltaGreenActor extends Actor {
       system.sanity.adaptations.helplessness.isAdapted = false;
     }
 
+    if(system.sanity.value <= system.sanity.currentBreakingPoint){
+      system.sanity.breakingPointHit = true;
+    }
+    else{
+      system.sanity.breakingPointHit = false;
+    }
+
     // calculate total armor rating
     let protection = 0;
     for (const i of agent.items) {

--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -504,14 +504,10 @@ export class DGDamageRoll extends DGRoll {
       this.options.rollMode || game.settings.get("core", "rollMode");
     let label = this.formula;
     try {
-      label = `${this.item.name}: ${game.i18n.localize(
-        "DG.Roll.Rolling",
-      )} <b>${game.i18n
-        .localize("DG.Roll.Damage")
-        .toUpperCase()}</b> ${game.i18n.localize(
-        "DG.Roll.For",
-      )} <b>${label.toUpperCase()}</b>`;
-    } catch {
+      label = `${game.i18n.localize("DG.Roll.Rolling",)} <b>${game.i18n.localize("DG.Roll.Damage").
+        toUpperCase()}</b> ${game.i18n.localize("DG.Roll.For",)} ${this.item.name}`;
+    } catch(ex) {
+      //console.log(ex);
       label = `Rolling <b>DAMAGE</b> for <b>${label.toUpperCase()}</b>`;
     }
     return this.createMessage(this.total, label, rollMode);

--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -132,12 +132,18 @@ export class DGPercentileRoll extends DGRoll {
    * @returns {Promise<Object|void>} - the results of the dialog.
    */
   async showDialog() {
-    let isSanCheck = false;
-    const hideSanTarget =
-      !game.user.isGM && game.settings.get("deltagreen", "keepSanityPrivate");
+    const privateSanSetting = game.settings.get(
+      "deltagreen",
+      "keepSanityPrivate",
+    );
 
-    if (this.key === "sanity" || this.key === "ritual") {
-      isSanCheck = true;
+    let hideSanTarget = false;
+    if (
+      privateSanSetting &&
+      (this.type === "sanity" || this.key === "ritual") &&
+      !game.user.isGM
+    ) {
+      hideSanTarget = true;
     }
 
     const backingData = {
@@ -145,7 +151,6 @@ export class DGPercentileRoll extends DGRoll {
         label: this.localizedKey,
         originalTarget: this.target,
         targetModifier: 20,
-        isSanCheck,
         hideTarget: hideSanTarget,
       },
     };
@@ -212,7 +217,7 @@ export class DGPercentileRoll extends DGRoll {
     );
     if (
       privateSanSetting &&
-      (this.key === "sanity" || this.key === "ritual") &&
+      (this.type === "sanity" || this.key === "ritual") &&
       !game.user.isGM
     ) {
       rollMode = "blindroll";

--- a/module/settings.js
+++ b/module/settings.js
@@ -26,6 +26,7 @@ export default function registerSystemSettings() {
     hint: "Hide sanity from players on both character sheet and rolls.",
     scope: "world",
     config: true,
+    requiresReload: true,
     type: Boolean,
     default: false,
   });
@@ -56,10 +57,12 @@ export default function registerSystemSettings() {
     hint: "Show Impossible Landscapes-specific fields from character sheets.",
     scope: "world",
     config: true,
+    requiresReload: true,
     type: Boolean,
     default: true,
   });
 
+  // obsolete - will be removed at some point
   game.settings.register("deltagreen", "characterSheetFont", {
     name: "World Font Choice",
     hint: "Choose font style for use throughout this world.",
@@ -83,6 +86,7 @@ export default function registerSystemSettings() {
     },
   });
 
+  // obsolete - will be removed at some point
   game.settings.register("deltagreen", "characterSheetBackgroundImageSetting", {
     name: "World Sheet Background Image",
     hint: "Choose background image for use throughout this world. (Refresh page to see change.)",

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -63,7 +63,7 @@
 
                 {{#unless (keepSanityPrivate)}}
  
-                  <input type="text" name="system.sanity.value" value="{{actor.system.sanity.value}}" data-dtype="Number" title="{{localize 'DG.Tooltip.CurrentSanityPartOne'}}{{actor.system.sanity.currentBreakingPoint}}{{localize 'DG.Tooltip.CurrentSanityPartTwo'}}" />
+                  <input class="{{#if actor.system.sanity.breakingPointHit}}breaking-point-hit{{/if}}" type="text" name="system.sanity.value" value="{{actor.system.sanity.value}}" data-dtype="Number" title="{{localize 'DG.Tooltip.CurrentSanityPartOne'}}{{actor.system.sanity.currentBreakingPoint}}{{localize 'DG.Tooltip.CurrentSanityPartTwo'}}" />
                   <span> / </span>
                   <div class="max-resource-value" title="{{localize 'DG.Tooltip.MaximumSanity'}}">
                     <div>{{numberFormat actor.system.sanity.max decimals=0 sign=false}}</div>

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -54,7 +54,7 @@
               <div class="resource-inner-grid-3col">
 
                 {{#if (keepSanityPrivate)}}
-                  <input type="text" value="??" disabled title="{{localize 'DG.Tooltip.CurrentSanityPartOne'}}{{system.sanity.currentBreakingPoint}}{{localize 'DG.Tooltip.CurrentSanityPartTwo'}}" />
+                  <input type="text" value="??" disabled title="" />
                   <span> / </span>
                   <div class="max-resource-value" title="{{localize 'DG.Tooltip.MaximumSanity'}}">
                     <div>{{numberFormat actor.system.sanity.max decimals=0 sign=false}}</div>
@@ -63,7 +63,7 @@
 
                 {{#unless (keepSanityPrivate)}}
  
-                  <input type="text" name="system.sanity.value" value="{{actor.system.sanity.value}}" data-dtype="Number" title="{{localize 'DG.Tooltip.CurrentSanityPartOne'}}{{system.sanity.currentBreakingPoint}}{{localize 'DG.Tooltip.CurrentSanityPartTwo'}}" />
+                  <input type="text" name="system.sanity.value" value="{{actor.system.sanity.value}}" data-dtype="Number" title="{{localize 'DG.Tooltip.CurrentSanityPartOne'}}{{actor.system.sanity.currentBreakingPoint}}{{localize 'DG.Tooltip.CurrentSanityPartTwo'}}" />
                   <span> / </span>
                   <div class="max-resource-value" title="{{localize 'DG.Tooltip.MaximumSanity'}}">
                     <div>{{numberFormat actor.system.sanity.max decimals=0 sign=false}}</div>


### PR DESCRIPTION
NOTE: Leaving as draft until PR #88 is merged

Issue #87 brought up that San rolls are not actually enforced to be private currently. This MR fixes that.

Steps to test:

1. Checkout this branch
2. Log into Foundry as a GM 
3. Open the settings and select "Keep Sanity Private"
4. Open an incognito window, and login as a player. Assign an actor to the player.
5. As a player, open actor sheet and ensure that SAN and Ritual are `??`. GM should still be able to see everything.
6. As a player, roll SAN. Player should see 
![image](https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/assets/72114365/09b712de-025f-4eee-932a-2ffe0d4b65e9)
7. As a player, roll Ritual. Player should see the same as above.
8. Shift-click and roll to open the modifier dialog. Player should see 
![image](https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/assets/72114365/4a3ea840-9e94-4f2e-9c94-72ecf121c692)
9. Try changing roll type to Public or any non-blind GM roll. Ensure that the roll is forced to be Blind GM Roll no matter what.
10. Repeat steps 8-9 with the Ritual skill.
11. Roll other skills/weapons/damage (with and without modification dialog) and make sure players can see their numbers (no `??`)