### PR TITLE
Fix issue with custom targets for weapons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release/Patch Notes
 
+### Version 1.3.3 - 2023-XX-XX
+
+- Fix [Github #93] - Custom target numbers for weapons can now be set correctly.
+
 ### Version 1.3.2 - 2023-10-07
 
 - Enhancement - When hitting a breakpoint, current SAN now turns bold and red, to help indicate you need to reset your breaking point.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release/Patch Notes
 
-### Version 1.3.3 - 2023-XX-XX
+### Version 1.3.3 - 2023-10-17
 
 - Fix [Github #93] - Custom target numbers for weapons can now be set correctly.
 

--- a/system.json
+++ b/system.json
@@ -15,7 +15,7 @@
       "discord": "jalensailin"
     }
   ],
-  "version": "1.3.2",
+  "version": "1.3.3",
   "compatibility": {
     "minimum": "11",
     "verified": "11"
@@ -129,7 +129,7 @@
     }
   ],
   "manifest": "https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/raw/master/system.json",
-  "download": "https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/releases/download/v1.3.2/deltagreen.zip",
+  "download": "https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/releases/download/v1.3.3/deltagreen.zip",
   "gridDistance": 1,
   "gridUnits": "m",
   "primaryTokenAttribute": "health",

--- a/templates/item/item-weapon-sheet.html
+++ b/templates/item/item-weapon-sheet.html
@@ -50,8 +50,8 @@
 
         <div class="weapon-sheet-horizontal-grid-right-2col">
           {{#if_eq item.system.skill 'custom'}}
-          <span class="resource-label">{{localize 'DG.ItemWindow.Weapons.CustomSkillTarget'}}:</span>
-          <input type="text" name="system.customSkillTarget" value="{{item.system.customSkillTarget}}" data-dtype="Number"/>
+            <span class="resource-label">{{localize 'DG.ItemWindow.Weapons.CustomSkillTarget'}}:</span>
+            <input type="text" name="system.customSkillTarget" value="{{../item.system.customSkillTarget}}" data-dtype="Number"/>
           {{/if_eq}}
         </div>
 


### PR DESCRIPTION
Addresses issue #93.

Steps to Test:

1. Create weapon item
2. Set skill to "Custom"
3. Set custom target number in the input box that appears.
4. Click into another input field and observe that the value inputted remains.
5. Drag weapon to an actor sheet and roll.
6. Observe that the custom target number is used in the roll evaluation