### PR TITLE
Update github workflow to automate version/links

### DIFF
--- a/.github/workflows/buildPacks.yml
+++ b/.github/workflows/buildPacks.yml
@@ -37,11 +37,24 @@ jobs:
       - run: fvtt package pack "operation-code-name-generator" --in "packs/source/operation-code-name-generator" --out "packs"
       - run: fvtt package pack "operation-code-name-generator-macro" --in "packs/source/operation-code-name-generator-macro" --out "packs"
       - run: fvtt package pack "pregens" --in "packs/source/pregens" --out "packs"
-      # 12. Zip up the branch with the LevelDB packs.
+      # 12. Get the version number without the leading -v.
+      - name: Get Version
+        id: get_version
+        uses: dhkatz/get-version-action@v3.0.0
+      # 13. Substitute the Manifest and Download URLs in the system.json
+      - name: Substitute Manifest, Download Links For Versioned Ones
+        uses: TomaszKandula/variable-substitution@v1.0.1
+        with:
+          files: "system.json"
+        env:
+          version: ${{steps.get_version.outputs.version-without-v}}
+          manifest: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.json
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/deltagreen.zip
+      # 14. Zip up the branch with the LevelDB packs.
       - name: Zip
         # Exclude the source json files from the final package, as well as any git folders.
-        run: zip -r deltagreen.zip . --exclude="*packs/source/*" --exclude="*.git*"
-      # 13. Updates the release with the newly zipped branch. See documentation of this action for details.
+        run: zip -r deltagreen.zip . --exclude="*packs/source/*" --exclude=".*" --exclude="package-lock.json" --exclude="package.json"
+      # 15. Updates the release with the newly zipped branch. See documentation of this action for details.
       - name: Update Release with Artifacts
         uses: ncipollo/release-action@v1.13.0
         with:
@@ -49,5 +62,5 @@ jobs:
           name: ${{ github.event.release.name }}
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}
-          artifacts: "./deltagreen.zip"
+          artifacts: "./deltagreen.zip, ./system.json"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/system.json
+++ b/system.json
@@ -15,7 +15,7 @@
       "discord": "jalensailin"
     }
   ],
-  "version": "1.3.3",
+  "version": "DUMMY_VALUE",
   "compatibility": {
     "minimum": "11",
     "verified": "11"
@@ -128,8 +128,8 @@
       }
     }
   ],
-  "manifest": "https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/raw/master/system.json",
-  "download": "https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/releases/download/v1.3.3/deltagreen.zip",
+  "manifest": "DUMMY_VALUE",
+  "download": "DUMMY_VALUE",
   "gridDistance": 1,
   "gridUnits": "m",
   "primaryTokenAttribute": "health",


### PR DESCRIPTION
The github workflow file has been updated to automate changing some of the values in `system.json`: `version`, `manifest`, and `download`. All we have to do is tag a release of the form `vX.Y.Z` and these values will automatically be updated with the correct links on build. In addition, the `system.json` file will be attached to the release along with the `deltagreen.zip`. This will make it really easy for someone to install a specific version of the system via manifest link alone, and it leaves less room for error on our part (i.e. we only have to write the correct version once, when making the tag.

This update also prevents development files/folders from being included in the `.zip`

To test:
> Note, this is kind of hard to test without merging first, since github will only recognize the action if its in the `master` branch. I'd review the few code changes and as long as you see no glaring mistakes, we can merge this, and then you/I can test everything.

1. Cut a release and assign a new tag `vTest` or something similar (start with a lower case `v`).
2. Let the build system do its thing.
3. Once build system has completed, check that the release has a `system.json` and a `deltagreen.zip` attached.
4. Ensure that the `download` and `manifest` fields in `system.json` do not point to dead links. 
5. Ensure that the `version` field in `system.json` reads `Test` (or whatever you named the tag, without the `v`).
6. Download the `deltagreen.zip` file and ensure that the `system.json` in there looks the same.
7. Ensure no development files such as `package.json`, `package-lock.json`, or any folder/file starting with a `.` is included in the `.zip`