### PR TITLE
Special Training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release/Patch Notes
 
+### Version 1.4.0 - TBD
+
+- Feature [Github #70] - Added ability to track and roll Special Training.
+- Enhancement - Slight restyle of Skill section of sheet, saving space.
+
 ### Version 1.3.5 - 2023-11-20
 
 - Working on improving the process for packing a new build, but some things have gone wrong. So no actual changes here, just iterating forward on the build to avoid some issues that cropped up.

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -448,6 +448,10 @@ input.breaking-point-hit {
   text-align: right;
 }
 
+.deltagreen .skill-and-training-controls {
+  flex: 0 0 80px;
+}
+
 .deltagreen .action-pill {
   padding: 2px;
   border-radius: 2.5px;

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -224,6 +224,14 @@ input.breaking-point-hit {
 .flex-thin-border {
   border: 1px solid #999;
   border-radius: 2px;
+  border-left-color: darkslategray;
+  border-left-width: 4px;
+}
+
+/* Make sure Special Training boxes are the same height
+   as all other skill boxes */
+.flex-thin-border.special-training-box {
+  min-height: 27px;
 }
 
 .flex-mid-border {
@@ -503,6 +511,7 @@ input.percentile-skill-input {
   flex: 0 0 40px;
   margin-right: 5px;
   margin-left: 5px;
+  height: unset;
 }
 
 input.checkbox-skill-input {

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -129,7 +129,7 @@ form.program-style {
   color: #999999;
 }
 
-input.breaking-point-hit{
+input.breaking-point-hit {
   color: rgb(117, 0, 0);
   font-weight: bold;
 }
@@ -438,6 +438,13 @@ input.breaking-point-hit{
   -ms-flex: 0 0 86px;
   flex: 0 0 86px;
   text-align: right;
+}
+
+.item-controls .item-control {
+  padding: 2px;
+  border-radius: 2.5px;
+  font-size: 0.8rem;
+  background-color: rgba(0, 0, 0, 0.185);
 }
 
 a.btn-tiny {

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -440,10 +440,11 @@ input.breaking-point-hit {
   text-align: right;
 }
 
-.item-controls .item-control {
+.deltagreen .action-pill {
   padding: 2px;
   border-radius: 2.5px;
   font-size: 0.8rem;
+  font-weight: bold;
   background-color: rgba(0, 0, 0, 0.185);
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -65,7 +65,8 @@
   "DG.TypeSkills.Science": "Science",
   "DG.TypeSkills.Other": "Other",
 
-  "DG.SpecialTraining.Dialog.AddSpecialTraining": "Add Special Training",
+  "DG.SpecialTraining.Dialog.CreateSpecialTraining": "Add Special Training",
+  "DG.SpecialTraining.Dialog.EditSpecialTraining": "Edit Special Training",
   "DG.SpecialTraining.Dialog.NameLabel": "Name",
   "DG.SpecialTraining.Dialog.SkillLabel": "Skill or Stat",
   "DG.SpecialTraining.Dialog.Title": "Create/Edit Special Training",

--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,9 @@
   "DG.TypeSkills.Other": "Other",
 
   "DG.SpecialTraining.Dialog.CreateSpecialTraining": "Add Special Training",
+  "DG.SpecialTraining.Dialog.DropDown.CustomSkills": "Custom/Typed Skills",
+  "DG.SpecialTraining.Dialog.DropDown.Skills": "Skills",
+  "DG.SpecialTraining.Dialog.DropDown.Statistics": "Statistics",
   "DG.SpecialTraining.Dialog.EditSpecialTraining": "Edit Special Training",
   "DG.SpecialTraining.Dialog.NameLabel": "Name",
   "DG.SpecialTraining.Dialog.SkillLabel": "Skill or Stat",

--- a/lang/en.json
+++ b/lang/en.json
@@ -44,7 +44,7 @@
   "DG.Skills.unarmed_combat": "Unarmed Combat",
   "DG.Skills.unnatural": "Unnatural",
 
-  "DG.Skills.AddTypedOrCustomSkill": "Add Typed or Custom Skill",
+  "DG.Skills.AddTypedOrCustomSkill": "Add Typed/Custom Skill",
   "DG.Skills.AddSkill": "Add Skill",
   "DG.Skills.Apply": "Apply",
   "DG.Skills.ApplySkillImprovements": "Apply Skill Improvements",

--- a/lang/en.json
+++ b/lang/en.json
@@ -65,6 +65,11 @@
   "DG.TypeSkills.Science": "Science",
   "DG.TypeSkills.Other": "Other",
 
+  "DG.SpecialTraining.Dialog.AddSpecialTraining": "Add Special Training",
+  "DG.SpecialTraining.Dialog.NameLabel": "Name",
+  "DG.SpecialTraining.Dialog.SkillLabel": "Skill or Stat",
+  "DG.SpecialTraining.Dialog.Title": "Create/Edit Special Training",
+
   "DG.Attributes.HP": "HP",
   "DG.Attributes.WP": "WP",
   "DG.Attributes.SAN": "SAN",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -75,22 +75,23 @@ export default class DeltaGreenActorSheet extends ActorSheet {
             name: training.name,
             id: training.id,
             key: training.attribute,
-            rollType: "skill",
           };
           // Convert the machine-readable name to a human-readable one.
           switch (true) {
+            // Stats
             case DG.statistics.includes(training.attribute):
               simplifiedTraining.attribute = training.attribute.toUpperCase();
               simplifiedTraining.targetNumber =
                 this.actor.system.statistics[training.attribute].value;
-              simplifiedTraining.rollType = "stat";
               break;
+            // Skills
             case DG.skills.includes(training.attribute):
               simplifiedTraining.attribute =
                 this.actor.system.skills[training.attribute].label;
               simplifiedTraining.targetNumber =
                 this.actor.system.skills[training.attribute].proficiency;
               break;
+            // Typed Skills
             default:
               simplifiedTraining.attribute =
                 this.actor.system.typedSkills[training.attribute].label;
@@ -910,6 +911,7 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       rollType: dataset.rolltype,
       key: dataset.key,
       actor: this.actor,
+      specialTrainingName: dataset?.name || null, // Only applies to Special Training Rolls
       item,
     };
 
@@ -919,6 +921,7 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       case "stat":
       case "skill":
       case "sanity":
+      case "special-training":
       case "weapon":
         roll = new DGPercentileRoll("1D100", {}, rollOptions);
         break;

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -304,6 +304,20 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       this.actor.update({ [`system.typedSkills.-=${targetskill}`]: null });
     });
 
+    // Handle deletion of
+    html.find(".special-training-delete").click((event) => {
+      event.preventDefault();
+      const targetID = event.target.getAttribute("data-id");
+      const specialTrainingArray = duplicate(this.actor.system.specialTraining);
+      // Get the index of the training to be deleted
+      const index = specialTrainingArray.findIndex(
+        (training) => training.id === targetID,
+      );
+
+      specialTrainingArray.splice(index, 1);
+      this.actor.update({ "system.specialTraining": specialTrainingArray });
+    });
+
     html.find(".apply-skill-improvements").click((event) => {
       event.preventDefault();
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1,4 +1,4 @@
-/* globals $ game Roll ChatMessage AudioHelper ActorSheet mergeObject Dialog TextEditor ActiveEffect ui duplicate fromUuidSync */
+/* globals $ game Roll ChatMessage AudioHelper ActorSheet mergeObject Dialog TextEditor ActiveEffect ui duplicate fromUuidSync renderTemplate */
 
 import {
   DGPercentileRoll,
@@ -304,7 +304,13 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       this.actor.update({ [`system.typedSkills.-=${targetskill}`]: null });
     });
 
-    // Handle deletion of
+    html.find(".special-training-add").click((event) => {
+      event.preventDefault();
+      const targetID = event.target.getAttribute("data-id");
+      this._showSpecialTrainingDialog(targetID);
+    });
+
+    // Handle deletion of Special Training
     html.find(".special-training-delete").click((event) => {
       event.preventDefault();
       const targetID = event.target.getAttribute("data-id");
@@ -659,9 +665,6 @@ export default class DeltaGreenActorSheet extends ActorSheet {
   }
 
   _addNewTypedSkill(newSkillLabel, newSkillGroup) {
-    const specialTraining = [
-      { name: "lockpicking", skill: "dex", id: randomID() },
-    ];
     const updatedData = duplicate(this.actor.system);
     const { typedSkills } = updatedData;
 
@@ -701,6 +704,37 @@ export default class DeltaGreenActorSheet extends ActorSheet {
 
       this.actor.update({ data: updatedData });
     }
+  }
+
+  async _showSpecialTrainingDialog(targetskill) {
+    const content = await renderTemplate(
+      "systems/deltagreen/templates/dialog/special-training.html",
+    );
+
+    new Dialog({
+      content,
+      title: game.i18n.localize("DG.SpecialTraining.Dialog.Title"),
+      default: "add",
+      buttons: {
+        add: {
+          label: game.i18n.localize(
+            "DG.SpecialTraining.Dialog.AddSpecialTraining",
+          ),
+          callback: (btn) => {
+            const specialTrainingLabel = btn
+              .find("[name='special-training-label']")
+              .val();
+            const specialTrainingSkill = btn
+              .find("[name='special-training-skill']")
+              .val();
+            this._addSpecialTraining(
+              specialTrainingLabel,
+              specialTrainingSkill,
+            );
+          },
+        },
+      },
+    }).render(true);
   }
 
   /**

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -237,8 +237,8 @@ export default class DeltaGreenActorSheet extends ActorSheet {
 
     // Rollable abilities - bind to everything with the 'Rollable' class
     html.find(".rollable").click(this._onRoll.bind(this));
-    html.find('.rollable').contextmenu(this._onRoll.bind(this)); // this is for right-click, which triggers the roll modifier dialogue for most rolls
-    
+    html.find(".rollable").contextmenu(this._onRoll.bind(this)); // this is for right-click, which triggers the roll modifier dialogue for most rolls
+
     html.find(".toggle-untrained").click(() =>
       this.actor.update({
         "system.showUntrainedSkills": !this.actor.system.showUntrainedSkills,
@@ -645,6 +645,9 @@ export default class DeltaGreenActorSheet extends ActorSheet {
   }
 
   _addNewTypedSkill(newSkillLabel, newSkillGroup) {
+    const specialTraining = [
+      { name: "lockpicking", skill: "dex", id: randomID() },
+    ];
     const updatedData = duplicate(this.actor.system);
     const { typedSkills } = updatedData;
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -68,39 +68,41 @@ export default class DeltaGreenActorSheet extends ActorSheet {
     }
 
     // Prepare a simplified version of the special training for display on sheet.
-    const specialTraining = this.actor.system.specialTraining.map(
-      (training) => {
-        const simplifiedTraining = {
-          name: training.name,
-          id: training.id,
-          key: training.attribute,
-          rollType: "skill",
-        };
-        // Convert the machine-readable name to a human-readable one.
-        switch (true) {
-          case DG.statistics.includes(training.attribute):
-            simplifiedTraining.attribute = training.attribute.toUpperCase();
-            simplifiedTraining.targetNumber =
-              this.actor.system.statistics[training.attribute].value;
-            simplifiedTraining.rollType = "stat";
-            break;
-          case DG.skills.includes(training.attribute):
-            simplifiedTraining.attribute =
-              this.actor.system.skills[training.attribute].label;
-            simplifiedTraining.targetNumber =
-              this.actor.system.skills[training.attribute].proficiency;
-            break;
-          default:
-            simplifiedTraining.attribute =
-              this.actor.system.typedSkills[training.attribute].label;
-            simplifiedTraining.targetNumber =
-              this.actor.system.typedSkills[training.attribute].proficiency;
-            break;
-        }
-        return simplifiedTraining;
-      },
-    );
-    data.specialTraining = specialTraining;
+    if (this.actor.type !== "vehicle") {
+      const specialTraining = this.actor.system.specialTraining.map(
+        (training) => {
+          const simplifiedTraining = {
+            name: training.name,
+            id: training.id,
+            key: training.attribute,
+            rollType: "skill",
+          };
+          // Convert the machine-readable name to a human-readable one.
+          switch (true) {
+            case DG.statistics.includes(training.attribute):
+              simplifiedTraining.attribute = training.attribute.toUpperCase();
+              simplifiedTraining.targetNumber =
+                this.actor.system.statistics[training.attribute].value;
+              simplifiedTraining.rollType = "stat";
+              break;
+            case DG.skills.includes(training.attribute):
+              simplifiedTraining.attribute =
+                this.actor.system.skills[training.attribute].label;
+              simplifiedTraining.targetNumber =
+                this.actor.system.skills[training.attribute].proficiency;
+              break;
+            default:
+              simplifiedTraining.attribute =
+                this.actor.system.typedSkills[training.attribute].label;
+              simplifiedTraining.targetNumber =
+                this.actor.system.typedSkills[training.attribute].proficiency;
+              break;
+          }
+          return simplifiedTraining;
+        },
+      );
+      data.specialTraining = specialTraining;
+    }
 
     switch (this.actor.type) {
       case "agent":

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -708,8 +708,33 @@ export default class DeltaGreenActorSheet extends ActorSheet {
   }
 
   async _showSpecialTrainingDialog(action, targetID) {
+    const specialTraining = this.actor.system.specialTraining.find(
+      (training) => training.id === targetID,
+    );
+
+    const skillList = Object.entries(this.actor.system.skills).map(
+      ([k, v]) => ({
+        key: k,
+        label: v.label,
+        targetNumber: v.proficiency,
+      }),
+    );
+    const typedSkillList = Object.values(this.actor.system.typedSkills).map(
+      (skill) => ({
+        key: skill.label,
+        group: skill.group,
+        label: skill.label,
+        targetNumber: skill.proficiency,
+      }),
+    );
+    const combinedSkillList = [...skillList, ...typedSkillList];
     const content = await renderTemplate(
       "systems/deltagreen/templates/dialog/special-training.html",
+      {
+        name: specialTraining?.name || "",
+        currentSkill: specialTraining?.skill || "",
+        skillList: combinedSkillList,
+      },
     );
 
     const buttonLabel = game.i18n.localize(

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -76,16 +76,16 @@ export default class DeltaGreenActorSheet extends ActorSheet {
         };
         // Convert the machine-readable name to a human-readable one.
         switch (true) {
-          case DG.statistics.includes(training.skill):
-            simplifiedTraining.skill = training.skill.toUpperCase();
+          case DG.statistics.includes(training.attribute):
+            simplifiedTraining.attribute = training.attribute.toUpperCase();
             break;
-          case DG.skills.includes(training.skill):
-            simplifiedTraining.skill =
-              this.actor.system.skills[training.skill].label;
+          case DG.skills.includes(training.attribute):
+            simplifiedTraining.attribute =
+              this.actor.system.skills[training.attribute].label;
             break;
           default:
-            simplifiedTraining.skill =
-              this.actor.system.typedSkills[training.skill].label;
+            simplifiedTraining.attribute =
+              this.actor.system.typedSkills[training.attribute].label;
             break;
         }
         return simplifiedTraining;
@@ -772,7 +772,7 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       "systems/deltagreen/templates/dialog/special-training.html",
       {
         name: specialTraining?.name || "",
-        currentSkill: specialTraining?.skill || "",
+        currentAttribute: specialTraining?.attribute || "",
         statList,
         skillList,
         typedSkillList,
@@ -795,18 +795,18 @@ export default class DeltaGreenActorSheet extends ActorSheet {
             const specialTrainingLabel = btn
               .find("[name='special-training-label']")
               .val();
-            const specialTrainingSkill = btn
+            const specialTrainingAttribute = btn
               .find("[name='special-training-skill']")
               .val();
             if (action === "Create")
               this._createSpecialTraining(
                 specialTrainingLabel,
-                specialTrainingSkill,
+                specialTrainingAttribute,
               );
             if (action === "Edit")
               this._editSpecialTraining(
                 specialTrainingLabel,
-                specialTrainingSkill,
+                specialTrainingAttribute,
                 targetID,
               );
           },
@@ -815,23 +815,23 @@ export default class DeltaGreenActorSheet extends ActorSheet {
     }).render(true);
   }
 
-  _createSpecialTraining(label, skill) {
+  _createSpecialTraining(label, attribute) {
     const specialTrainingArray = duplicate(this.actor.system.specialTraining);
     specialTrainingArray.push({
       name: label,
-      skill,
+      attribute,
       id: randomID(),
     });
     this.actor.update({ "system.specialTraining": specialTrainingArray });
   }
 
-  _editSpecialTraining(label, skill, id) {
+  _editSpecialTraining(label, attribute, id) {
     const specialTrainingArray = duplicate(this.actor.system.specialTraining);
     const specialTraining = specialTrainingArray.find(
       (training) => training.id === id,
     );
     specialTraining.name = label;
-    specialTraining.skill = skill;
+    specialTraining.attribute = attribute;
     this.actor.update({ "system.specialTraining": specialTrainingArray });
   }
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -73,19 +73,28 @@ export default class DeltaGreenActorSheet extends ActorSheet {
         const simplifiedTraining = {
           name: training.name,
           id: training.id,
+          key: training.attribute,
+          rollType: "skill",
         };
         // Convert the machine-readable name to a human-readable one.
         switch (true) {
           case DG.statistics.includes(training.attribute):
             simplifiedTraining.attribute = training.attribute.toUpperCase();
+            simplifiedTraining.targetNumber =
+              this.actor.system.statistics[training.attribute].value;
+            simplifiedTraining.rollType = "stat";
             break;
           case DG.skills.includes(training.attribute):
             simplifiedTraining.attribute =
               this.actor.system.skills[training.attribute].label;
+            simplifiedTraining.targetNumber =
+              this.actor.system.skills[training.attribute].proficiency;
             break;
           default:
             simplifiedTraining.attribute =
               this.actor.system.typedSkills[training.attribute].label;
+            simplifiedTraining.targetNumber =
+              this.actor.system.typedSkills[training.attribute].proficiency;
             break;
         }
         return simplifiedTraining;

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -18,7 +18,7 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       classes: ["deltagreen", "sheet", "actor"],
       template: "systems/deltagreen/templates/actor/actor-sheet.html",
       width: 700,
-      height: 800,
+      height: 770,
       tabs: [
         {
           navSelector: ".sheet-tabs",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -306,8 +306,8 @@ export default class DeltaGreenActorSheet extends ActorSheet {
 
     html.find(".special-training-action").click((event) => {
       event.preventDefault();
-      const action = event.target.getAttribute("data-action");
-      const targetID = event.target.getAttribute("data-id");
+      const action = event.currentTarget.getAttribute("data-action");
+      const targetID = event.currentTarget.getAttribute("data-id");
       this._showSpecialTrainingDialog(action, targetID);
     });
 
@@ -730,24 +730,40 @@ export default class DeltaGreenActorSheet extends ActorSheet {
             const specialTrainingSkill = btn
               .find("[name='special-training-skill']")
               .val();
-            this._addSpecialTraining(
-              specialTrainingLabel,
-              specialTrainingSkill,
-              targetID,
-            );
+            if (action === "Create")
+              this._createSpecialTraining(
+                specialTrainingLabel,
+                specialTrainingSkill,
+              );
+            if (action === "Edit")
+              this._editSpecialTraining(
+                specialTrainingLabel,
+                specialTrainingSkill,
+                targetID,
+              );
           },
         },
       },
     }).render(true);
   }
 
-  _addSpecialTraining(label, skill) {
+  _createSpecialTraining(label, skill) {
     const specialTrainingArray = duplicate(this.actor.system.specialTraining);
     specialTrainingArray.push({
       name: label,
       skill,
       id: randomID(),
     });
+    this.actor.update({ "system.specialTraining": specialTrainingArray });
+  }
+
+  _editSpecialTraining(label, skill, id) {
+    const specialTrainingArray = duplicate(this.actor.system.specialTraining);
+    const specialTraining = specialTrainingArray.find(
+      (training) => training.id === id,
+    );
+    specialTraining.name = label;
+    specialTraining.skill = skill;
     this.actor.update({ "system.specialTraining": specialTrainingArray });
   }
 

--- a/module/config.js
+++ b/module/config.js
@@ -1,0 +1,55 @@
+/**
+ * In config.js we can create constants that may be used all around the code base.
+ * I tried to get some of these values from `game.system` but it seems they
+ * aren't loaded yet when this is called. Oh well, this shouldn't really ever
+ * change.
+ */
+
+const DG = {
+  // All the base skills
+  skills: [
+    "accounting",
+    "alertness",
+    "anthropology",
+    "archeology",
+    "artillery",
+    "athletics",
+    "bureaucracy",
+    "computer_science",
+    "criminology",
+    "demolitions",
+    "disguise",
+    "dodge",
+    "drive",
+    "firearms",
+    "first_aid",
+    "forensics",
+    "heavy_machiner",
+    "heavy_weapons",
+    "history",
+    "humint",
+    "law",
+    "medicine",
+    "melee_weapons",
+    "navigate",
+    "occult",
+    "persuade",
+    "pharmacy",
+    "psychotherapy",
+    "ride",
+    "search",
+    "sigint",
+    "stealth",
+    "surgery",
+    "survival",
+    "swim",
+    "unarmed_combat",
+    "unnatural",
+    "ritual",
+  ],
+
+  // All the base rollable stats.
+  statistics: ["str", "con", "dex", "int", "pow", "cha"],
+};
+
+export default DG;

--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -97,6 +97,24 @@ export class DGPercentileRoll extends DGRoll {
           this.localizedKey = `${skill.group} (${skill.label})`;
         }
         break;
+      case "special-training": {
+        this.specialTrainingName = options.specialTrainingName;
+        if (statKeys.includes(this.key)) {
+          this.target = this.actor.system.statistics[this.key].x5;
+          this.localizedKey = game.i18n.localize(`DG.Attributes.${this.key}`);
+        }
+        if (skillKeys.includes(this.key)) {
+          this.target = this.actor.system.skills[this.key].proficiency;
+          this.localizedKey = game.i18n.localize(`DG.Skills.${this.key}`);
+        }
+        if (typedSkillKeys.includes(this.key)) {
+          const skill = this.actor.system.typedSkills[this.key];
+          this.target = skill.proficiency;
+          this.localizedKey = `${skill.group} (${skill.label})`;
+        }
+        this.localizedKey = `${this.specialTrainingName} - (${this.localizedKey})`;
+        break;
+      }
       case "sanity":
         this.target = this.actor.system.sanity.value;
         this.localizedKey = game.i18n.localize("DG.Attributes.SAN");

--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -504,10 +504,13 @@ export class DGDamageRoll extends DGRoll {
       this.options.rollMode || game.settings.get("core", "rollMode");
     let label = this.formula;
     try {
-      label = `${game.i18n.localize("DG.Roll.Rolling",)} <b>${game.i18n.localize("DG.Roll.Damage").
-        toUpperCase()}</b> ${game.i18n.localize("DG.Roll.For",)} ${this.item.name}`;
-    } catch(ex) {
-      //console.log(ex);
+      label = `${game.i18n.localize("DG.Roll.Rolling")} <b>${game.i18n
+        .localize("DG.Roll.Damage")
+        .toUpperCase()}</b> ${game.i18n.localize("DG.Roll.For")} ${
+        this.item.name
+      }`;
+    } catch (ex) {
+      // console.log(ex);
       label = `Rolling <b>DAMAGE</b> for <b>${label.toUpperCase()}</b>`;
     }
     return this.createMessage(this.total, label, rollMode);

--- a/module/templates.js
+++ b/module/templates.js
@@ -12,6 +12,7 @@ export default async function preloadHandlebarsTemplates() {
     "systems/deltagreen/templates/actor/unnatural-sheet.html",
     "systems/deltagreen/templates/actor/npc-sheet.html",
     "systems/deltagreen/templates/actor/cv-partial.html",
+    "systems/deltagreen/templates/actor/custom-skills-partial.html",
     "systems/deltagreen/templates/dialog/modify-percentile-roll.html",
     "systems/deltagreen/templates/actor/vehicle-sheet.html",
     "systems/deltagreen/templates/actor/help-and-licensing-partial.html",

--- a/template.json
+++ b/template.json
@@ -234,7 +234,8 @@
             "proficiency": 0,
             "failure": false
           }
-        }
+        },
+        "specialTraining": []
       },
       "unnatural_skills": {
         "skills": {
@@ -423,7 +424,8 @@
             "proficiency": 0
           }
         },
-        "typedSkills": {}
+        "typedSkills": {},
+        "specialTraining": []
       }
     },
     "unnatural": {

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -112,14 +112,14 @@
 
                     {{#if (keepSanityPrivate)}}
                       <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="??" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
-                      <input type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
+                      <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
                         title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
                         />
                     {{/if}}
 
                     {{#unless (keepSanityPrivate)}}
                       <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
-                      <input type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
+                      <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
                         title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
                         />
                     {{/unless}}
@@ -128,7 +128,7 @@
 
                   {{#if_not_eq key 'ritual' }}
                     <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
-                    <input type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
+                    <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
                       title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
                       />
                   {{/if_not_eq}}

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -139,8 +139,9 @@
 
           <div>
             <div class="item-controls skill-util-buttons">
-              <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a> 
-              <a class="item-control apply-skill-improvements">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-plus"></i></a>
+              <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
+              <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
+              <a class="item-control apply-skill-improvements">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-dice"></i></a>
             </div>
             <div class="grid-2col">
               {{#each actor.system.typedSkills as |skill key|}}
@@ -153,6 +154,17 @@
                   </label>
                   <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
                   <input type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
+                  <div class="item-controls">
+                      <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
+                      <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+                  </div>
+                </div>
+              {{/each}}
+              {{#each actor.system.specialTraining as |training|}}
+                <div class="item flexrow flex-group-center flex-thin-border">
+                  <label class="">
+                    {{training.name}}
+                  </label>
                   <div class="item-controls">
                       <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
                       <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -137,41 +137,9 @@
               {{/each}}
           </div>
 
+          {{!-- Custom Skills and Special Training --}}
           <div>
-            <div class="item-controls skill-util-buttons">
-              <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
-              <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
-              <a class="item-control apply-skill-improvements">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-dice"></i></a>
-            </div>
-            <div class="grid-2col">
-              {{#each actor.system.typedSkills as |skill key|}}
-                <div class="item flexrow flex-group-center flex-thin-border">
-                  <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-key="{{key}}" data-rolltype="skill" data-roll="d100" data-target="{{skill.proficiency}}" data-label="{{skill.label}}" 
-                      {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
-                      {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}} 
-                    >
-                    {{skill.group}} ({{skill.label}})
-                  </label>
-                  <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
-                  <input type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
-                  <div class="item-controls">
-                      <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-                      <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
-                  </div>
-                </div>
-              {{/each}}
-              {{#each actor.system.specialTraining as |training|}}
-                <div class="item flexrow flex-group-center flex-thin-border">
-                  <label class="">
-                    {{training.name}}
-                  </label>
-                  <div class="item-controls">
-                      <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-                      <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
-                  </div>
-                </div>
-              {{/each}}
-            </div>
+            {{> "systems/deltagreen/templates/actor/custom-skills-partial.html" actorType="agent"}}
           </div>
         </div>
 

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -243,7 +243,7 @@
                 <div class="item-name">{{localize 'DG.Mental.Motivations'}}</div>
                 <div class="item-name">{{localize 'DG.Mental.Disorders'}}</div>
                 <div class="item-controls">
-                  <a class="item-control item-create" title="Create item" data-type="motivation"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+                  <a class="item-control item-create action-pill" title="Create item" data-type="motivation"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
                 </div>
               </li>
 
@@ -291,7 +291,7 @@
                 <span class="centered-item-property">{{localize 'DG.Gear.DamageOrLethality'}}</span>
                 <span class="centered-item-property">{{localize 'DG.Gear.ArmorPiercing'}}</span>
                 <div class="item-controls">
-                  <a class="item-control item-create" title="Create item" data-type="weapon"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>                  
+                  <a class="item-control item-create action-pill" title="Create item" data-type="weapon"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>                  
                 </div>
               </li>
 
@@ -361,7 +361,7 @@
                 <span class="centered-item-property">{{localize 'DG.Gear.ArmorRating'}}</span>
                 <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
                 <div class="item-controls">
-                  <a class="item-control item-create" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+                  <a class="item-control item-create action-pill" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
                 </div>
               </li>
 
@@ -405,7 +405,7 @@
                 
                 <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
                 <div class="item-controls">
-                  <a class="item-control item-create" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+                  <a class="item-control item-create action-pill" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
                 </div>
               </li>
 
@@ -464,7 +464,7 @@
                 <div class="item-name">{{localize 'DG.Bonds.Relationship'}}</div>
                 <div class="item-name">{{localize 'DG.Bonds.Score'}}</div>                
                 <div class="item-controls">
-                  <a class="item-control item-create" title="Create item" data-type="bond"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+                  <a class="item-control item-create action-pill" title="Create item" data-type="bond"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
                 </div>
               </li>
 

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -1,8 +1,8 @@
 <div class="item-controls skill-util-buttons">
-  <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
-  <a class="item-control special-training-action" data-action="Create"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
+  <a class="item-control typed-skill-add action-pill"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
+  <a class="item-control special-training-action action-pill" data-action="Create"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
   {{#if_eq actorType "agent"}}
-    <a class="item-control apply-skill-improvements">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-dice"></i></a>
+    <a class="item-control apply-skill-improvements action-pill">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-dice"></i></a>
   {{/if_eq}}
 </div>
 <div class="grid-2col">

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -8,19 +8,21 @@
 <div class="grid-2col">
   {{#each actor.system.typedSkills as |skill key|}}
     <div class="item flexrow flex-group-center flex-thin-border">
-      <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-key="{{key}}" data-rolltype="skill" data-roll="d100" data-target="{{skill.proficiency}}" data-label="{{skill.label}}" 
-          {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
-          {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}} 
-        >
-        {{skill.group}} ({{skill.label}})
-      </label>
-      <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
-      {{#if_eq actorType "agent"}}
-        <input class="checkbox-skill-input" type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
-      {{/if_eq}}
-      <div class="item-controls">
-          <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-          <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+      <div class="flexrow">
+        <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-key="{{key}}" data-rolltype="skill" data-roll="d100" data-target="{{skill.proficiency}}" data-label="{{skill.label}}" 
+            {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
+            {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}} 
+          >
+          {{skill.group}} ({{skill.label}})
+        </label>
+        <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
+        {{#if_eq actorType "agent"}}
+          <input class="checkbox-skill-input" type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
+        {{/if_eq}}
+      </div>
+      <div class="item-controls skill-and-training-controls">
+        <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
+        <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
       </div>
     </div>
   {{/each}}
@@ -29,7 +31,7 @@
       <label class="{{if_gt training.targetNumber 0 'rollable' 'not-rollable'}}" data-key="{{training.key}}" data-rolltype="{{training.rollType}}">
         {{training.name}} ({{training.attribute}} - {{training.targetNumber}})
       </label>
-      <div class="item-controls">
+      <div class="item-controls skill-and-training-controls">
           <a class="item-control special-training-action" data-action="Edit" data-id="{{training.id}}" title="Edit Training"><i class="fas fa-edit"></i></a>
           <a class="item-control special-training-delete" title="Delete Training" data-id="{{training.id}}" ><i class="fas fa-trash"></i></a>
       </div>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -28,8 +28,8 @@
         {{training.name}}
       </label>
       <div class="item-controls">
-          <a class="item-control special-training-action" data-action="Edit" title="Edit Training"><i class="fas fa-edit" data-id="{{training.id}}" ></i></a>
-          <a class="item-control special-training-delete" title="Delete Training"><i class="fas fa-trash" data-id="{{key}}" ></i></a>
+          <a class="item-control special-training-action" data-action="Edit" data-id="{{training.id}}" title="Edit Training"><i class="fas fa-edit"></i></a>
+          <a class="item-control special-training-delete" title="Delete Training" data-id="{{training.id}}" ><i class="fas fa-trash"></i></a>
       </div>
     </div>
   {{/each}}

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -28,8 +28,8 @@
         {{training.name}}
       </label>
       <div class="item-controls">
-          <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-          <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+          <a class="item-control special-training-edit" title="Edit Training"><i class="fas fa-edit" data-id="{{training.id}}" ></i></a>
+          <a class="item-control special-training-delete" title="Delete Training"><i class="fas fa-trash" data-id="{{key}}" ></i></a>
       </div>
     </div>
   {{/each}}

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -15,7 +15,9 @@
         {{skill.group}} ({{skill.label}})
       </label>
       <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
-      <input class="checkbox-skill-input" type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
+      {{#if_eq actorType "agent"}}
+        <input class="checkbox-skill-input" type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
+      {{/if_eq}}
       <div class="item-controls">
           <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
           <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -15,7 +15,7 @@
         {{skill.group}} ({{skill.label}})
       </label>
       <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
-      <input type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
+      <input class="checkbox-skill-input" type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
       <div class="item-controls">
           <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
           <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
@@ -23,7 +23,7 @@
     </div>
   {{/each}}
   {{#each specialTraining as |training|}}
-    <div class="item flexrow flex-group-center flex-thin-border">
+    <div class="item flexrow flex-group-center flex-thin-border special-training-box">
       <label class="{{if_gt training.targetNumber 0 'rollable' 'not-rollable'}}" data-key="{{training.key}}" data-rolltype="{{training.rollType}}">
         {{training.name}} ({{training.attribute}} - {{training.targetNumber}})
       </label>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -22,7 +22,7 @@
       </div>
     </div>
   {{/each}}
-  {{#each actor.system.specialTraining as |training|}}
+  {{#each specialTraining as |training|}}
     <div class="item flexrow flex-group-center flex-thin-border">
       <label class="">
         {{training.name}} ({{training.skill}})

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -25,7 +25,7 @@
   {{#each actor.system.specialTraining as |training|}}
     <div class="item flexrow flex-group-center flex-thin-border">
       <label class="">
-        {{training.name}}
+        {{training.name}} ({{training.skill}})
       </label>
       <div class="item-controls">
           <a class="item-control special-training-action" data-action="Edit" data-id="{{training.id}}" title="Edit Training"><i class="fas fa-edit"></i></a>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -25,7 +25,7 @@
   {{#each specialTraining as |training|}}
     <div class="item flexrow flex-group-center flex-thin-border">
       <label class="">
-        {{training.name}} ({{training.skill}})
+        {{training.name}} ({{training.attribute}})
       </label>
       <div class="item-controls">
           <a class="item-control special-training-action" data-action="Edit" data-id="{{training.id}}" title="Edit Training"><i class="fas fa-edit"></i></a>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -28,7 +28,7 @@
   {{/each}}
   {{#each specialTraining as |training|}}
     <div class="item flexrow flex-group-center flex-thin-border special-training-box">
-      <label class="{{if_gt training.targetNumber 0 'rollable' 'not-rollable'}}" data-key="{{training.key}}" data-rolltype="{{training.rollType}}">
+      <label class="{{if_gt training.targetNumber 0 'rollable' 'not-rollable'}}" data-key="{{training.key}}" data-name="{{training.name}}" data-rolltype="special-training">
         {{training.name}} ({{training.attribute}} - {{training.targetNumber}})
       </label>
       <div class="item-controls skill-and-training-controls">

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -1,0 +1,36 @@
+<div class="item-controls skill-util-buttons">
+  <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
+  <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
+  {{#if_eq actorType "agent"}}
+    <a class="item-control apply-skill-improvements">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-dice"></i></a>
+  {{/if_eq}}
+</div>
+<div class="grid-2col">
+  {{#each actor.system.typedSkills as |skill key|}}
+    <div class="item flexrow flex-group-center flex-thin-border">
+      <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-key="{{key}}" data-rolltype="skill" data-roll="d100" data-target="{{skill.proficiency}}" data-label="{{skill.label}}" 
+          {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
+          {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}} 
+        >
+        {{skill.group}} ({{skill.label}})
+      </label>
+      <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
+      <input type="checkbox" name="system.typedSkills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} />
+      <div class="item-controls">
+          <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
+          <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+      </div>
+    </div>
+  {{/each}}
+  {{#each actor.system.specialTraining as |training|}}
+    <div class="item flexrow flex-group-center flex-thin-border">
+      <label class="">
+        {{training.name}}
+      </label>
+      <div class="item-controls">
+          <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
+          <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+      </div>
+    </div>
+  {{/each}}
+</div>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -24,8 +24,8 @@
   {{/each}}
   {{#each specialTraining as |training|}}
     <div class="item flexrow flex-group-center flex-thin-border">
-      <label class="">
-        {{training.name}} ({{training.attribute}})
+      <label class="{{if_gt training.targetNumber 0 'rollable' 'not-rollable'}}" data-key="{{training.key}}" data-rolltype="{{training.rollType}}">
+        {{training.name}} ({{training.attribute}} - {{training.targetNumber}})
       </label>
       <div class="item-controls">
           <a class="item-control special-training-action" data-action="Edit" data-id="{{training.id}}" title="Edit Training"><i class="fas fa-edit"></i></a>

--- a/templates/actor/custom-skills-partial.html
+++ b/templates/actor/custom-skills-partial.html
@@ -1,6 +1,6 @@
 <div class="item-controls skill-util-buttons">
   <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
-  <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
+  <a class="item-control special-training-action" data-action="Create"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
   {{#if_eq actorType "agent"}}
     <a class="item-control apply-skill-improvements">{{localize 'DG.Skills.ApplySkillImprovements'}}<i class="fas fa-dice"></i></a>
   {{/if_eq}}
@@ -28,7 +28,7 @@
         {{training.name}}
       </label>
       <div class="item-controls">
-          <a class="item-control special-training-edit" title="Edit Training"><i class="fas fa-edit" data-id="{{training.id}}" ></i></a>
+          <a class="item-control special-training-action" data-action="Edit" title="Edit Training"><i class="fas fa-edit" data-id="{{training.id}}" ></i></a>
           <a class="item-control special-training-delete" title="Delete Training"><i class="fas fa-trash" data-id="{{key}}" ></i></a>
       </div>
     </div>

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -128,8 +128,9 @@
       </div>
       <br>
       <div>
-        <div class="item-controls">
+        <div class="item-controls skill-util-buttons">
           <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
+          <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
         </div>
         <div class="grid-2col">
           {{#each actor.system.typedSkills as |skill key|}}
@@ -149,6 +150,17 @@
               </div>
             </div>
             {{/if}}
+          {{/each}}
+          {{#each actor.system.specialTraining as |training|}}
+            <div class="item flexrow flex-group-center flex-thin-border">
+              <label class="">
+                {{training.name}}
+              </label>
+              <div class="item-controls">
+                  <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
+                  <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+              </div>
+            </div>
           {{/each}}
         </div>
       </div>

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -128,41 +128,7 @@
       </div>
       <br>
       <div>
-        <div class="item-controls skill-util-buttons">
-          <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
-          <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
-        </div>
-        <div class="grid-2col">
-          {{#each actor.system.typedSkills as |skill key|}}
-            {{#if (hideSkillBasedOnProficiencyAndUserChoice ../actor.system.showUntrainedSkills skill.proficiency)}}
-            <div class="item flexrow flex-group-center flex-thin-border">
-              <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-rolltype="skill" data-roll="d100" data-target="{{skill.proficiency}}" data-key="{{key}}" 
-                  {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
-                  {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}} 
-                >
-                {{skill.group}} ({{skill.label}})
-              </label>
-              <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
-              
-              <div class="item-controls">
-                  <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-                  <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
-              </div>
-            </div>
-            {{/if}}
-          {{/each}}
-          {{#each actor.system.specialTraining as |training|}}
-            <div class="item flexrow flex-group-center flex-thin-border">
-              <label class="">
-                {{training.name}}
-              </label>
-              <div class="item-controls">
-                  <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-                  <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
-              </div>
-            </div>
-          {{/each}}
-        </div>
+        {{> "systems/deltagreen/templates/actor/custom-skills-partial.html"}}
       </div>
       <br>
       <div>

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -158,7 +158,7 @@
             <span class="centered-item-property">{{localize 'DG.Gear.DamageOrLethality'}}</span>
             <span class="centered-item-property">{{localize 'DG.Gear.ArmorPiercing'}}</span>
             <div class="item-controls">
-              <a class="item-control item-create" title="Create item" data-type="weapon"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+              <a class="item-control item-create action-pill" title="Create item" data-type="weapon"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
             </div>
           </li>
 
@@ -228,7 +228,7 @@
             <span class="centered-item-property">{{localize 'DG.Gear.ArmorRating'}}</span>
             <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
             <div class="item-controls">
-              <a class="item-control item-create" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+              <a class="item-control item-create action-pill" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
             </div>
           </li>
 
@@ -272,7 +272,7 @@
             <div class="item-name"></div>
             <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
             <div class="item-controls">
-              <a class="item-control item-create" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+              <a class="item-control item-create action-pill" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
             </div>
           </li>
 

--- a/templates/actor/unnatural-sheet.html
+++ b/templates/actor/unnatural-sheet.html
@@ -121,41 +121,7 @@
       </div>
       <br>
       <div>
-        <div class="item-controls skill-util-buttons">
-          <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
-          <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
-        </div>
-        <div class="grid-2col">
-          {{#each actor.system.typedSkills as |skill key|}}
-            {{#if (hideSkillBasedOnProficiencyAndUserChoice ../actor.system.showUntrainedSkills skill.proficiency)}}
-            <div class="item flexrow flex-group-center flex-thin-border">
-              <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-rolltype="skill" data-key="{{key}}" 
-                  {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
-                  {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}} 
-                >
-                {{skill.group}} ({{skill.label}})
-              </label>
-              <input class="percentile-skill-input" type="text" name="system.typedSkills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number"/>
-              
-              <div class="item-controls">
-                  <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-                  <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
-              </div>
-            </div>
-            {{/if}}
-          {{/each}}
-          {{#each actor.system.specialTraining as |training|}}
-            <div class="item flexrow flex-group-center flex-thin-border">
-              <label class="">
-                {{training.name}}
-              </label>
-              <div class="item-controls">
-                  <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
-                  <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
-              </div>
-            </div>
-          {{/each}}
-        </div>
+        {{> "systems/deltagreen/templates/actor/custom-skills-partial.html"}}
       </div>
       <br>
       <div>

--- a/templates/actor/unnatural-sheet.html
+++ b/templates/actor/unnatural-sheet.html
@@ -151,7 +151,7 @@
             <span class="centered-item-property">{{localize 'DG.Gear.DamageOrLethality'}}</span>
             <span class="centered-item-property">{{localize 'DG.Gear.ArmorPiercing'}}</span>
             <div class="item-controls">
-              <a class="item-control item-create" title="Create item" data-type="weapon"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+              <a class="item-control item-create action-pill" title="Create item" data-type="weapon"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
             </div>
           </li>
 
@@ -220,7 +220,7 @@
             <span class="centered-item-property">{{localize 'DG.Gear.ArmorRating'}}</span>
             <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
             <div class="item-controls">
-              <a class="item-control item-create" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+              <a class="item-control item-create action-pill" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
             </div>
           </li>
 
@@ -264,7 +264,7 @@
             <div class="item-name"></div>
             <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
             <div class="item-controls">
-              <a class="item-control item-create" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+              <a class="item-control item-create action-pill" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
             </div>
           </li>
 

--- a/templates/actor/unnatural-sheet.html
+++ b/templates/actor/unnatural-sheet.html
@@ -121,8 +121,9 @@
       </div>
       <br>
       <div>
-        <div class="item-controls">
+        <div class="item-controls skill-util-buttons">
           <a class="item-control typed-skill-add"><i class="fas fa-plus"></i>{{localize 'DG.Skills.AddTypedOrCustomSkill'}}</a>
+          <a class="item-control special-training-add"><i class="fas fa-plus"></i>{{localize 'Add Special Training'}}</a> 
         </div>
         <div class="grid-2col">
           {{#each actor.system.typedSkills as |skill key|}}
@@ -142,6 +143,17 @@
               </div>
             </div>
             {{/if}}
+          {{/each}}
+          {{#each actor.system.specialTraining as |training|}}
+            <div class="item flexrow flex-group-center flex-thin-border">
+              <label class="">
+                {{training.name}}
+              </label>
+              <div class="item-controls">
+                  <a class="item-control typed-skill-edit" title="Edit Skill"><i class="fas fa-edit" data-typedskill="{{key}}" ></i></a>
+                  <a class="item-control typed-skill-delete" title="Delete Skill"><i class="fas fa-trash" data-typedskill="{{key}}" ></i></a>
+              </div>
+            </div>
           {{/each}}
         </div>
       </div>

--- a/templates/actor/vehicle-sheet.html
+++ b/templates/actor/vehicle-sheet.html
@@ -73,7 +73,7 @@
               <span class="centered-item-property">{{localize 'DG.Gear.ArmorRating'}}</span>
               <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
               <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+                <a class="item-control item-create action-pill" title="Create item" data-type="armor"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
               </div>
             </li>
   
@@ -117,7 +117,7 @@
               <div class="item-name"></div>
               <span class="centered-item-property">{{localize 'DG.Gear.Equipped'}}</span>
               <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
+                <a class="item-control item-create action-pill" title="Create item" data-type="gear"><i class="fas fa-plus"></i> {{localize 'DG.Generic.AddButtonLabel'}}</a>
               </div>
             </li>
   

--- a/templates/dialog/special-training.html
+++ b/templates/dialog/special-training.html
@@ -3,12 +3,24 @@
     <label>
       {{localize "DG.SpecialTraining.Dialog.NameLabel"}}
     </label>
-    <input type="text" name="special-training-label" />
+    <input type="text" name="special-training-label" value="{{name}}"/>
   </div>
   <div class="flexrow">
     <label>
       {{localize "DG.SpecialTraining.Dialog.SkillLabel"}}
     </label>
-    <input type="text" name="special-training-skill" />
+    {{#select currentSkill}}
+      <select name="special-training-skill">
+        {{#each skillList as |skill|}}
+          <option value="{{skill.key}}">
+            {{#if skill.group}}
+              {{skill.group}} ({{skill.label}})
+            {{else}}
+              {{skill.label}}
+            {{/if}}
+          </option>
+        {{/each}}
+      </select>
+    {{/select}}
   </div>
 </form>

--- a/templates/dialog/special-training.html
+++ b/templates/dialog/special-training.html
@@ -1,0 +1,14 @@
+<form class="flexcol">
+  <div class="flexrow">
+    <label>
+      {{localize "DG.SpecialTraining.Dialog.NameLabel"}}
+    </label>
+    <input type="text" name="special-training-label" />
+  </div>
+  <div class="flexrow">
+    <label>
+      {{localize "DG.SpecialTraining.Dialog.SkillLabel"}}
+    </label>
+    <input type="text" name="special-training-skill" />
+  </div>
+</form>

--- a/templates/dialog/special-training.html
+++ b/templates/dialog/special-training.html
@@ -11,15 +11,27 @@
     </label>
     {{#select currentSkill}}
       <select name="special-training-skill">
-        {{#each skillList as |skill|}}
-          <option value="{{skill.key}}">
-            {{#if skill.group}}
-              {{skill.group}} ({{skill.label}})
-            {{else}}
+        <optgroup label="{{localize "DG.SpecialTraining.Dialog.DropDown.Statistics"}}"> 
+          {{#each statList as |stat|}}
+            <option value="{{stat.key}}" data-type="stat">
+              {{stat.label}}
+            </option>
+          {{/each}}
+        </optgroup>  
+        <optgroup label="{{localize "DG.SpecialTraining.Dialog.DropDown.Skills"}}"> 
+          {{#each skillList as |skill|}}
+            <option value="{{skill.key}}" data-type="skill">
               {{skill.label}}
-            {{/if}}
-          </option>
-        {{/each}}
+            </option>
+          {{/each}}
+        </optgroup>        
+        <optgroup label="{{localize "DG.SpecialTraining.Dialog.DropDown.CustomSkills"}}"> 
+          {{#each typedSkillList as |skill|}}
+            <option value="{{skill.key}}" data-type="typedSkill">
+              {{skill.group}} ({{skill.label}})
+            </option>
+          {{/each}}
+        </optgroup>
       </select>
     {{/select}}
   </div>

--- a/templates/dialog/special-training.html
+++ b/templates/dialog/special-training.html
@@ -9,7 +9,7 @@
     <label>
       {{localize "DG.SpecialTraining.Dialog.SkillLabel"}}
     </label>
-    {{#select currentSkill}}
+    {{#select currentAttribute}}
       <select name="special-training-skill">
         <optgroup label="{{localize "DG.SpecialTraining.Dialog.DropDown.Statistics"}}"> 
           {{#each statList as |stat|}}


### PR DESCRIPTION
Adds the ability to track and roll special training from the sheet, and a slight restyle of the Skills section of the sheet to go along with it.

**Important Dev Notes:**
- I split out the Custom Skill / Special Training into its own handlebars partial so that it could be repeated across the different actor sheets with more ease.

**Steps To Test:**

1. Checkout this branch on an existing world, if possible.
2. Make sure existing characters open correctly.
3. Add a special training to an actor using the new UI button on the sheet (next to `Add Custom/Typed Skill`).
4. Give it a name and choose a Stat attribute associated with the Training.
5. Repeat steps 3-4 and choose a Skill, then Typed/Custom Skill associated with the training, so there is a Special Training for each.
6. Roll each special training and make sure everything works as intended.
7. Double check that all other roll types still work.
8. Repeat 1-7 for Unnatural and NPC actors