### PR TITLE
Sort skills by column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Release/Patch Notes
 
+### Version 1.4.3 - ???
+
+- Feature [Github #101] - New user setting: Sort skills by column, rather than row.
+
+### Version 1.4.2 - 2024-01-28
+
+- Fix for issues around skills reverting to "Art - Painting".
+- Added German Translation provided by KarstenW76.
+
 ### Version 1.4.1 - 2023-12-13
 
 - Fix [Github #99] - Last round of changes caused checkbox for improvement on type (Art - XXX) skills to disappear, fixed.

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -208,6 +208,14 @@ input.breaking-point-hit {
   grid-template-columns: repeat(12, minmax(0, 1fr));
 }
 
+/* If the user wishes to sort skills by column, we need to 
+explicitly define a number of rows, rather than columns. */
+.grid-13row {
+  grid-template-rows: repeat(13, minmax(0, auto)) !important;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr)) !important;
+  grid-auto-flow: column !important;
+}
+
 .flex-group-center,
 .flex-group-left,
 .flex-group-right {

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -67,6 +67,9 @@ export default class DeltaGreenActorSheet extends ActorSheet {
       this._prepareCharacterItems(data);
     }
 
+    // Make it easy for the sheet handlebars to understand how to sort the skills.
+    data.sortSkillsSetting = game.settings.get("deltagreen", "sortSkills");
+
     // Prepare a simplified version of the special training for display on sheet.
     if (this.actor.type !== "vehicle") {
       const specialTraining = this.actor.system.specialTraining.map(

--- a/module/settings.js
+++ b/module/settings.js
@@ -21,6 +21,16 @@ export default function registerSystemSettings() {
     },
   });
 
+  game.settings.register("deltagreen", "sortSkills", {
+    name: "Sort Skills By Column?",
+    hint: "Checked sorts by column. Unchecked sorts by row.",
+    scope: "client",
+    config: true,
+    requiresReload: false,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register("deltagreen", "keepSanityPrivate", {
     name: "Keep Sanity Private",
     hint: "Hide sanity from players on both character sheet and rolls.",

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -96,45 +96,39 @@
             <span>{{localize "DG.Sheet.BlockHeaders.SkillsAndTraining"}}</span>                                                    
           </div>
           
-            <div class="grid grid-3col">
-
-              {{#each actor.system.skills as |skill key|}}
-              
-                <div class="flexrow flex-group-center flex-thin-border">
-                  <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-key="{{key}}" data-rolltype="skill" for="system.skills.{{key}}.value" 
-                      {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
-                      {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}}
-                    >
-                    {{localizeWithFallback (concat "DG.Skills." key) skill.label }}
-                  </label>
-                  
-                  {{#if_eq key 'ritual' }}
-
-                    {{#if (keepSanityPrivate)}}
-                      <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="??" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
-                      <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
-                        title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
-                        />
-                    {{/if}}
-
-                    {{#unless (keepSanityPrivate)}}
-                      <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
-                      <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
-                        title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
-                        />
-                    {{/unless}}
-                    
-                  {{/if_eq}}
-
-                  {{#if_not_eq key 'ritual' }}
+          <div class="grid grid-3col {{#if sortSkillsSetting}}grid-13row{{/if}}">
+            {{#each actor.system.skills as |skill key|}}
+              <div class="flexrow flex-group-center flex-thin-border">
+                <label class="{{if_gt skill.proficiency 0 'rollable' 'not-rollable'}} skill-label" data-key="{{key}}" data-rolltype="skill" for="system.skills.{{key}}.value" 
+                    {{#if skill.proficiency}}title="{{localize 'DG.Tooltip.SkillLabel'}}"{{/if}}
+                    {{#unless skill.proficiency}}title="{{localize 'DG.Tooltip.CannotRollSkillLabel'}}"{{/unless}}
+                  >
+                  {{localizeWithFallback (concat "DG.Skills." key) skill.label }}
+                </label>
+                
+                {{#if_eq key 'ritual' }}
+                  {{#if (keepSanityPrivate)}}
+                    <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="??" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
+                    <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
+                      title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
+                      />
+                  {{/if}}
+                  {{#unless (keepSanityPrivate)}}
                     <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
                     <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
                       title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
                       />
-                  {{/if_not_eq}}
-
-                </div>
-              {{/each}}
+                  {{/unless}}
+                  
+                {{/if_eq}}
+                {{#if_not_eq key 'ritual' }}
+                  <input class="percentile-skill-input" type="text" name="system.skills.{{key}}.proficiency" value="{{skill.proficiency}}" data-dtype="Number" {{#if skill.isCalculatedValue}} disabled {{/if}}/>
+                  <input class="checkbox-skill-input" type="checkbox" name="system.skills.{{key}}.failure" {{checked skill.failure}} data-dtype="Boolean" {{#if skill.cannotBeImprovedByFailure}} disabled {{/if}} 
+                    title="{{localize 'DG.Tooltip.SkillFailCheckbox'}}"
+                    />
+                {{/if_not_eq}}
+              </div>
+            {{/each}}
           </div>
 
           {{!-- Custom Skills and Special Training --}}

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -108,7 +108,7 @@
           <i class="far fa-eye{{#if actor.system.showUntrainedSkills}}-slash{{/if}}"></i>
         </a>
       </div>
-      <div class="grid grid-3col">
+      <div class="grid grid-3col {{#if sortSkillsSetting}}grid-13row{{/if}}">
         {{#each actor.system.skills as |skill key|}}
           
           {{#if (hideSkillBasedOnProficiencyAndUserChoice ../actor.system.showUntrainedSkills skill.proficiency)}}

--- a/templates/actor/unnatural-sheet.html
+++ b/templates/actor/unnatural-sheet.html
@@ -101,7 +101,7 @@
           <i class="far fa-eye{{#if actor.system.showUntrainedSkills}}-slash{{/if}}"></i>
         </a>
       </div>
-      <div class="grid grid-3col">
+      <div class="grid grid-3col {{#if sortSkillsSetting}}grid-13row{{/if}}">
         {{#each actor.system.skills as |skill key|}}
           
           {{#if (hideSkillBasedOnProficiencyAndUserChoice ../actor.system.showUntrainedSkills skill.proficiency)}}


### PR DESCRIPTION
This MR addresses #101.

**Steps to test:** 

1. Go to Delta Green settings and select "Sort Skills By Column" checkbox.
2. Open an Agent, NPC, and Unnatural actor sheet. 
3. Hide and unhide skills on the NPC/Unnatural sheet.
4. Check that the sorting has changed to column and that the styling for each sheet looks okay.
5. Go back to the settings and unselect "Sort Skills By Column" checkbox.
6. Make sure all skills are now sorted by row and the styling still looks correct.