### PR TITLE
Prevent grid warning in Foundry v12

### DIFF
--- a/system.json
+++ b/system.json
@@ -144,6 +144,10 @@
   "download": "https://github.com/TheLastScrub/delta-green-foundry-vtt-system-unofficial/releases/latest/download/deltagreen.zip",
   "gridDistance": 1,
   "gridUnits": "m",
+  "grid": {
+    "distance": 1,
+    "units": "m"
+  },
   "primaryTokenAttribute": "health",
   "secondaryTokenAttribute": "wp"
 }


### PR DESCRIPTION
Add grid.distance and grid.units to prevent warnings on v12. The old gridDistance and gridUnits are still required until v11 compatibility is dropped.